### PR TITLE
Eliminated the warning message caused by spec

### DIFF
--- a/spec/banking_spec.rb
+++ b/spec/banking_spec.rb
@@ -20,7 +20,7 @@ describe "BankAccount" do
     end
 
     it "can't change its name" do
-      expect { avi.name = "Bob" }.to raise_error
+      expect { avi.name = "Bob" }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
There was a warning message thrown about no error type. I added (ArgumentError) on line 43 because that is the expected error.

#staff